### PR TITLE
Allow Cross-Origin XMLHttpRequest to Safari Book Online

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -20,6 +20,7 @@
     "activeTab",
     "tabs",
     "pageCapture",
-    "downloads"
+    "downloads",
+    "*://*.safaribooksonline.com/*"
   ]
 }


### PR DESCRIPTION
See: https://developer.chrome.com/extensions/xhr

Otherwise, the extension threw a CORS error and refused to load the books infos.